### PR TITLE
Generalize dynamics dispatch to allow for extensions

### DIFF
--- a/src/joint_types/joint_types.jl
+++ b/src/joint_types/joint_types.jl
@@ -4,7 +4,9 @@ function flip_direction(jt::JointType{T}) where {T}
     error("Flipping direction is not supported for $(typeof(jt))")
 end
 
-@propagate_inbounds zero_configuration!(q::AbstractVector, ::JointType) = (q .= 0; nothing)
+@propagate_inbounds function zero_configuration!(q::AbstractVector{T}, ::JointType) where {T}
+    return (q .= zero(T); nothing)
+end
 
 @propagate_inbounds function local_coordinates!(ϕ::AbstractVector, ϕ̇::AbstractVector,
         jt::JointType, q0::AbstractVector, q::AbstractVector, v::AbstractVector)

--- a/src/mechanism_algorithms.jl
+++ b/src/mechanism_algorithms.jl
@@ -722,25 +722,39 @@ function contact_dynamics!(result::DynamicsResult{T, M}, state::MechanismState{X
     end
 end
 
+function dynamics_solve!(_v̇::AbstractVector, λ::AbstractVector,
+    G::AbstractMatrix, _c::AbstractVector, k::AbstractVector, nv::Int, nl::Int, τ::AbstractVector
+)
+    c = parent(_c)
+    r = [τ - c; -k]
+    v̇ = parent(_v̇)
+    v̇λ = G \ r
+    v̇ .= view(v̇λ, 1 : nv)
+    λ .= view(v̇λ, nv + 1 : nv + nl)
+    nothing
+end
+
 function dynamics_solve!(result::DynamicsResult, τ::AbstractVector)
     # version for general scalar types
     # TODO: make more efficient
     M = result.massmatrix
-    c = parent(result.dynamicsbias)
-    v̇ = parent(result.v̇)
+    # println("M: ", M.data)
+    # c = parent(result.dynamicsbias)
+    # v̇ = parent(result.v̇)
 
     K = result.constraintjacobian
-    k = result.constraintbias
-    λ = result.λ
+    # k = result.constraintbias
+    # λ = result.λ
 
     nv = size(M, 1)
     nl = size(K, 1)
     G = [Matrix(M) K'; # TODO: Matrix because of https://github.com/JuliaLang/julia/issues/21332
          K zeros(nl, nl)]
-    r = [τ - c; -k]
-    v̇λ = G \ r
-    v̇ .= view(v̇λ, 1 : nv)
-    λ .= view(v̇λ, nv + 1 : nv + nl)
+    # r = [τ - c; -k]
+    # v̇λ = G \ r
+    # v̇ .= view(v̇λ, 1 : nv)
+    # λ .= view(v̇λ, nv + 1 : nv + nl)
+    dynamics_solve!(result.v̇, result.λ, G, result.dynamicsbias, result.constraintbias, nv, nl, τ)
     nothing
 end
 

--- a/src/spatial/motion_force_interaction.jl
+++ b/src/spatial/motion_force_interaction.jl
@@ -170,7 +170,7 @@ Transform the `SpatialInertia` to a different frame.
     mcnew = Rmc + mp
     X = Rmc * transpose(p)
     Y = X + transpose(X) + mp * transpose(p)
-    Jnew = R * J * transpose(R) - Y + tr(Y) * I
+    Jnew = R * J * transpose(R) - Y + tr(Y) * I(3)
 
     SpatialInertia(t.to, Jnew, mcnew, m)
 end


### PR DESCRIPTION
## Motivation

This is a naive attempt to allow for dispatching dynamics using JuMP variables. In some ways, similar to what is done for [SymPy](https://juliarobotics.org/RigidBodyDynamics.jl/stable/generated/6.%20Symbolics%20using%20SymPy/6.%20Symbolics%20using%20SymPy/).

## Usage

The intended use is something like
```
# define Mechanism
mech = ... Mechanism ...

# Create JuMP variables
model = Model()

@variable(model, x[1:nx])
@variable(model, -torque_limits[i] <= u[i=1:atlas.nu] <= torque_limits[i])

# Define dynamics symbolically
statecache = StateCache(mech)
dyn_result = DynamicsResultCache(mech)
state =statecache[NonlinearExpr]
dyn_result = dynrescache[NonlinearExpr]

# Set the mechanism state
copyto!(state, convert.(NonlinearExpr, x))

# # Perform forward dynamics
dynamics!(dyn_result, state, convert.(NonlinearExpr,u))

K = [dyn_result.q̇; dyn_result.v̇]

# Use K or multiple Ks in a simple integrator
@constraint(model, x[t+1, :] == integrator(k...))

...
```